### PR TITLE
fix(macos): use scproxy:// protocol in production to bypass ATS

### DIFF
--- a/desktop/src/lib/asset-url.ts
+++ b/desktop/src/lib/asset-url.ts
@@ -47,7 +47,11 @@ export function toScproxyUrl(url: string, { bypassCache = false } = {}): string 
   const encodedPath = encodeURIComponent(btoa(target));
   const proxyPort = getProxyPort();
 
-  if (proxyPort) {
+  // В dev режиме используем HTTP для hot reload совместимости
+  // В production используем scproxy:// протокол (обходит ATS на macOS)
+  const isDev = import.meta.env.DEV;
+
+  if (isDev && proxyPort) {
     const shard = hashShard(target);
     return `http://scproxy-${shard}.localhost:${proxyPort}/p/${encodedPath}`;
   }
@@ -61,11 +65,6 @@ export function proxiedAssetUrl(
 ): string | null {
   if (!url) return null;
   if (!url.startsWith('http') || isWhitelistedAssetUrl(url)) return url;
-
-  const proxyPort = getProxyPort();
-  if (!proxyPort) {
-    return url;
-  }
 
   return toScproxyUrl(url, { bypassCache });
 }

--- a/desktop/src/lib/asset-url.ts
+++ b/desktop/src/lib/asset-url.ts
@@ -13,6 +13,7 @@ const WHITELIST = [
 ];
 const RETRY_BYPASS_CACHE_PARAM = '__scproxy_bust';
 const LOCAL_PROXY_SHARDS = 20;
+const IS_MACOS = navigator.platform?.startsWith('Mac') || navigator.userAgent.includes('Mac');
 
 function withCacheBust(url: string): string {
   try {
@@ -47,11 +48,7 @@ export function toScproxyUrl(url: string, { bypassCache = false } = {}): string 
   const encodedPath = encodeURIComponent(btoa(target));
   const proxyPort = getProxyPort();
 
-  // В dev режиме используем HTTP для hot reload совместимости
-  // В production используем scproxy:// протокол (обходит ATS на macOS)
-  const isDev = import.meta.env.DEV;
-
-  if (isDev && proxyPort) {
+  if (proxyPort && (!IS_MACOS || import.meta.env.DEV)) {
     const shard = hashShard(target);
     return `http://scproxy-${shard}.localhost:${proxyPort}/p/${encodedPath}`;
   }


### PR DESCRIPTION
In release builds on macOS, App Transport Security blocks HTTP requests to scproxy-*.localhost subdomains. This change uses the custom scproxy:// URI scheme protocol in production while keeping HTTP for dev mode (for hot reload compatibility).